### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,6 @@ php:
   - 5.5
   - 5.4
 
-matrix:
-  include:
-    - php: 5.3
-      dist: precise
-
 before_script:
   - composer install --dev --no-interaction
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: php
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - 5.6
+  - 5.5
+  - 5.4
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
+
+before_script:
+  - composer install --dev --no-interaction
+
+script:
+  - php vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,15 @@
             "email": "joris@statik.be"
         }
     ],
+    "require": {
+        "php": ">=5.3"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^4.8 | ^5.5 | ^6.5"
+    },
+    "suggest": {
+        "ext-fileinfo": "using finfo_ functions to create the Fileinfo Mime sniffer"
+    },
     "autoload": {
         "psr-0": {
             "ride\\library\\mime\\": ["src/"],

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8 | ^5.5 | ^6.5"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="true"
+         verbose="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+
+    <testsuites>
+        <testsuite name="Mime Test Suite">
+            <directory>test/src/ride/library/mime</directory>
+            <directory>test/src/ride/service</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
+
+</phpunit>

--- a/test/src/ride/library/mime/MediaTypeTest.php
+++ b/test/src/ride/library/mime/MediaTypeTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\mime;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MediaTypeTest extends PHPUnit_Framework_TestCase {
+class MediaTypeTest extends TestCase {
 
     /**
      * @dataProvider providerToString
@@ -21,6 +21,7 @@ class MediaTypeTest extends PHPUnit_Framework_TestCase {
             array('text/html; charset=UTF-8', 'text', 'html', array('charset' => 'UTF-8')),
             array('text/plain; charset=ISO-8859-1; format=flowed; delsp=yes', 'text', 'plain', array('charset' => 'ISO-8859-1', 'format' => 'flowed', 'delsp' => 'yes')),
             array('text/plain', 'text', 'plain', null),
+            array('multipart/byteranges; boundary=""', 'multipart', 'byteranges', array('boundary' => null)),
         );
     }
 
@@ -38,6 +39,163 @@ class MediaTypeTest extends PHPUnit_Framework_TestCase {
             array('xml', 'application', 'x-rss+xml', null),
             array(null, 'text', 'plain', null),
         );
+    }
+
+    /**
+     * @expectedException ride\library\mime\exception\MimeException
+     */
+    public function testSetTypeShouldThrowMimeException() {
+        $mediaType = new MediaType(1234, 'json');
+    }
+
+    public function testGetType() {
+        $mediaType = new MediaType('application', 'json');
+
+        $this->assertSame('application', $mediaType->getType());
+    }
+
+    public function testGetSubType() {
+        $mediaType = new MediaType('application', 'json');
+
+        $this->assertSame('json', $mediaType->getSubtype());
+    }
+
+    public function testGetTreeShouldReturnNull() {
+        $mediaType = new MediaType('application', 'json');
+
+        $this->assertNull($mediaType->getTree());
+    }
+
+    public function testGetTree() {
+        $mediaType = new MediaType('application', '*.json');
+
+        $this->assertSame('.json', $mediaType->getTree());
+    }
+
+    public function testGetParameters() {
+        $mediaType = new MediaType('text', 'html', array('charset' => 'utf-8'));
+
+        $this->assertSame(array('charset' => 'utf-8'), $mediaType->getParameters());
+    }
+
+    public function testGetParameterOnNull() {
+        $mediaType = new MediaType('text', 'html', array('charset' => 'utf-8'));
+
+        $this->assertNull($mediaType->getParameter('invalid_key'));
+    }
+
+    public function testGetParameter() {
+        $mediaType = new MediaType('text', 'html', array('charset' => 'utf-8'));
+
+        $this->assertSame('utf-8', $mediaType->getParameter('charset'));
+    }
+
+    public function testIsApplicationShouldReturnFalse() {
+        $mediaType = new MediaType('text', 'plain');
+
+        $this->assertFalse($mediaType->isApplication());
+    }
+
+    public function testIsApplicationShouldReturnTrue() {
+        $mediaType = new MediaType('application', 'json');
+
+        $this->assertTrue($mediaType->isApplication());
+    }
+
+    public function testIsAudioShouldReturnTrue() {
+        $mediaType = new MediaType('audio', 'ogg');
+
+        $this->assertTrue($mediaType->isAudio());
+    }
+
+    public function testIsAudioShouldReturnFalse() {
+        $mediaType = new MediaType('text', 'html');
+
+        $this->assertFalse($mediaType->isAudio());
+    }
+
+    public function testIsExampleShouldReturnFalse() {
+        $mediaType = new MediaType('text', 'html');
+
+        $this->assertFalse($mediaType->isExample());
+    }
+
+    public function testIsExampleShouldReturntTrue() {
+        $mediaType = new MediaType('example', 'html');
+
+        $this->assertTrue($mediaType->isExample());
+    }
+
+    public function testIsImageShouldReturnTrue() {
+        $mediaType = new MediaType('image', 'png');
+
+        $this->assertTrue($mediaType->isImage());
+    }
+
+    public function testIsImageShouldReturnFalse() {
+        $mediaType = new MediaType('text', 'plain');
+
+        $this->assertFalse($mediaType->isImage());
+    }
+
+    public function testIsMessageShouldReturnTrue() {
+        $mediaType = new MediaType('message', 'msg');
+
+        $this->assertTrue($mediaType->isMessage());
+    }
+
+    public function testIsMessageShouldReturnFalse() {
+        $mediaType = new MediaType('example', 'html');
+
+        $this->assertFalse($mediaType->isMessage());
+    }
+
+    public function testIsModelShouldReturnTrue() {
+        $mediaType = new MediaType('model', 'msg');
+
+        $this->assertTrue($mediaType->isModel());
+    }
+
+    public function testIsModelShouldReturnFalse() {
+        $mediaType = new MediaType('example', 'html');
+
+        $this->assertFalse($mediaType->isModel());
+    }
+
+    public function testIsMultipartShouldReturnTrue() {
+        $mediaType = new MediaType('multipart', 'byteranges');
+
+        $this->assertTrue($mediaType->isMultipart());
+    }
+
+    public function testIsMultipartShouldReturnFalse() {
+        $mediaType = new MediaType('example', 'html');
+
+        $this->assertFalse($mediaType->isMultipart());
+    }
+
+    public function testIsTextShouldReturnTrue() {
+        $mediaType = new MediaType('text', 'plain');
+
+        $this->assertTrue($mediaType->isText());
+    }
+
+    public function testIsTextShouldReturnFalse() {
+        $mediaType = new MediaType('example', 'html');
+
+        $this->assertFalse($mediaType->isText());
+    }
+
+    public function testIsVideoShouldReturnTrue() {
+        $mediaType = new MediaType('video', 'mp4');
+
+        $this->assertTrue($mediaType->isVideo());
+    }
+
+    public function testIsVideoShouldReturnFalse() {
+        $mediaType = new MediaType('example', 'html');
+
+        $this->assertFalse($mediaType->isVideo());
     }
 
 }

--- a/test/src/ride/library/mime/MimeFactoryTest.php
+++ b/test/src/ride/library/mime/MimeFactoryTest.php
@@ -2,12 +2,16 @@
 
 namespace ride\library\mime;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MimeFactoryTest extends PHPUnit_Framework_TestCase {
+class MimeFactoryTest extends TestCase {
 
     public function setUp() {
         $this->mimeFactory = new MimeFactory();
+    }
+
+    public function testCreateMediaTypeFromStringShouldReturnNull() {
+        $this->assertNull($this->mimeFactory->createMediaTypeFromString(null));
     }
 
     public function testCreateMimeTypes() {
@@ -71,7 +75,7 @@ video/mpeg mpeg mpg mpe
     public function testCreateMediaTypeFromString($expected) {
         $result = $this->mimeFactory->createMediaTypeFromString($expected);
 
-        $this->assertTrue($result instanceof MediaType);
+        $this->assertInstanceOf('ride\library\mime\MediaType', $result);
         $this->assertEquals($expected, (string) $result);
     }
 
@@ -81,6 +85,25 @@ video/mpeg mpeg mpg mpe
             array('text/html; charset=UTF-8'),
             array('text/plain'),
         );
+    }
+
+    public function testCreateMediaTypeFromStringOnParameters() {
+        $result = $this->mimeFactory->createMediaTypeFromString('image/jpg; name="myFile"; filename="img.jpg"');
+
+        $this->assertSame('image/jpg; name=myFile', (string) $result);
+    }
+
+    public function testCreateMediaTypeFromStringOnMediaTypeParameter() {
+        $result = $this->mimeFactory->createMediaTypeFromString('text/plain; filename');
+
+        $this->assertSame('text/plain; filename=1', (string) $result);
+    }
+
+    /**
+     * @expectedException ride\library\mime\exception\MimeException
+     */
+    public function testCreateMediaTypeFromStringShouldThrowMimeException() {
+        $result = $this->mimeFactory->createMediaTypeFromString(';');
     }
 
 }

--- a/test/src/ride/library/mime/MimeTypesTest.php
+++ b/test/src/ride/library/mime/MimeTypesTest.php
@@ -2,9 +2,15 @@
 
 namespace ride\library\mime;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MimeTypesTest extends PHPUnit_Framework_TestCase {
+class MimeTypesTest extends TestCase {
+
+    public function testGetExtensionShouldReturnDefaultValue() {
+        $mimeTypes = new MimeTypes();
+
+        $this->assertSame('txt', $mimeTypes->getExtension(null, 'txt'));
+    }
 
     public function testSetMediaType() {
         $mimeTypes = new MimeTypes();

--- a/test/src/ride/library/mime/sniffer/AbstractMimeSnifferTest.php
+++ b/test/src/ride/library/mime/sniffer/AbstractMimeSnifferTest.php
@@ -2,9 +2,9 @@
 
 namespace ride\library\mime\sniffer;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-abstract class AbstractMimeSnifferTest extends PHPUnit_Framework_TestCase {
+abstract class AbstractMimeSnifferTest extends TestCase {
 
     abstract protected function getMimeSniffer();
 

--- a/test/src/ride/service/MimeServiceTest.php
+++ b/test/src/ride/service/MimeServiceTest.php
@@ -6,9 +6,9 @@ use ride\library\mime\sniffer\FinfoMimeSniffer;
 use ride\library\mime\MediaType;
 use ride\library\mime\MimeFactory;
 
-use \PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
-class MimeServiceTest extends PHPUnit_Framework_TestCase {
+class MimeServiceTest extends TestCase {
 
     public function setUp() {
         $mimeFactory = new MimeFactory();
@@ -16,6 +16,18 @@ class MimeServiceTest extends PHPUnit_Framework_TestCase {
         $mimeSniffer = new FinfoMimeSniffer();
 
         $this->mimeService = new MimeService($mimeFactory, $mimeTypes, $mimeSniffer);
+    }
+
+    public function testGetMimeTypes() {
+        $mediaType = $this->mimeService->getMediaType('text/plain');
+
+        $this->assertInstanceOf('ride\library\mime\MimeTypes', $this->mimeService->getMimeTypes());
+    }
+
+    public function testGetMediaTypeShouldReturnNull() {
+        $mediaType = $this->mimeService->getMediaType('text/plain');
+
+        $this->assertNull($this->mimeService->getMediaType(null));
     }
 
     public function testGetMediaType() {


### PR DESCRIPTION
# Changed log

- add more tests.
- according to this [bug report](https://bugs.php.net/bug.php?id=53035), it seems that the ```php-5.3``` will detect the wrong mime type when executing the ```finfo_file``` function. So I drop the ```php-5.3``` support.
- Integrate the Travis build. See the current Travis build [log](https://travis-ci.org/peter279k/ride-lib-mime/builds/361084958).